### PR TITLE
Add basic calendar and navigation to Android app

### DIFF
--- a/android.py
+++ b/android.py
@@ -1,9 +1,11 @@
 import os
 import json
-from datetime import datetime, date
+import calendar
+from datetime import datetime, date, timedelta
 
 from kivy.app import App
 from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.gridlayout import GridLayout
 from kivy.uix.button import Button
 from kivy.uix.label import Label
 from kivy.uix.textinput import TextInput
@@ -183,8 +185,86 @@ class BudgetCalculator:
     def add_transaction(self, t):
         self.transactions.append(t)
 
+    def remove_transaction(self, t):
+        if t in self.transactions:
+            self.transactions.remove(t)
+
     def add_paycheck(self, p):
         self.paychecks.append(p)
+
+    def remove_paycheck(self, p):
+        if p in self.paychecks:
+            self.paychecks.remove(p)
+
+    # --- Date based helpers copied from app.py ---
+    def get_transactions_for_date(self, target_date):
+        return self.get_all_transactions_for_date(target_date)
+
+    def get_all_transactions_for_date(self, target_date):
+        all_transactions = []
+
+        for trans in self.transactions:
+            if self._transaction_occurs_on_date(trans, target_date):
+                all_transactions.append(trans)
+
+        for paycheck in self.paychecks:
+            p_trans = paycheck.to_transaction()
+            if self._transaction_occurs_on_date(p_trans, target_date):
+                all_transactions.append(p_trans)
+
+        return all_transactions
+
+    def _transaction_occurs_on_date(self, transaction, target_date):
+        start_date = transaction.start_date
+        end_date = transaction.end_date
+
+        if target_date < start_date:
+            return False
+        if end_date and target_date > end_date:
+            return False
+
+        if transaction.frequency == "one-time":
+            return start_date == target_date
+        elif transaction.frequency == "daily":
+            return True
+        elif transaction.frequency == "weekly":
+            days_diff = (target_date - start_date).days
+            return days_diff >= 0 and days_diff % 7 == 0
+        elif transaction.frequency == "bi-weekly":
+            days_diff = (target_date - start_date).days
+            return days_diff >= 0 and days_diff % 14 == 0
+        elif transaction.frequency == "monthly":
+            if target_date.day == start_date.day:
+                return True
+            if start_date.day > target_date.day:
+                last_day = calendar.monthrange(target_date.year, target_date.month)[1]
+                return target_date.day == last_day and start_date.day > last_day
+            return False
+        elif transaction.frequency == "yearly":
+            return target_date.month == start_date.month and target_date.day == start_date.day
+        return False
+
+    def calculate_daily_total(self, target_date):
+        txns = self.get_transactions_for_date(target_date)
+        total_income = sum(t.amount for t in txns if t.transaction_type == "income")
+        total_expenses = sum(t.amount for t in txns if t.transaction_type == "expense")
+        return total_income - total_expenses
+
+    def get_calendar_data(self, year, month):
+        cal_data = {}
+        first_day = date(year, month, 1)
+        last_day = date(year, month, calendar.monthrange(year, month)[1])
+
+        current_date = first_day
+        while current_date <= last_day:
+            daily_total = self.calculate_daily_total(current_date)
+            cal_data[current_date.day] = {
+                'total': daily_total,
+                'transactions': self.get_transactions_for_date(current_date)
+            }
+            current_date += timedelta(days=1)
+
+        return cal_data
 
     def to_dict(self):
         return {
@@ -220,7 +300,115 @@ class TransactionsView(RecycleView):
     def refresh(self, items):
         self.data = [{'text': i} for i in items]
 
-class HomeScreen(Screen):
+class CalendarScreen(Screen):
+    def __init__(self, app, **kwargs):
+        super().__init__(**kwargs)
+        self.app = app
+        self.current_month = datetime.now().month
+        self.current_year = datetime.now().year
+
+        layout = BoxLayout(orientation='vertical')
+
+        header = BoxLayout(size_hint_y=0.1)
+        header.add_widget(Button(text='<', on_release=lambda x: self.prev_month()))
+        self.month_label = Label(text='')
+        header.add_widget(self.month_label)
+        header.add_widget(Button(text='>', on_release=lambda x: self.next_month()))
+        layout.add_widget(header)
+
+        self.grid = GridLayout(cols=7)
+        layout.add_widget(self.grid)
+
+        bottom = BoxLayout(size_hint_y=0.1)
+        bottom.add_widget(Button(text='Transactions', on_release=lambda x: setattr(app.sm, 'current', 'transactions')))
+        bottom.add_widget(Button(text='Paychecks', on_release=lambda x: setattr(app.sm, 'current', 'paychecks')))
+        layout.add_widget(bottom)
+
+        self.add_widget(layout)
+        self.update_calendar()
+
+    def prev_month(self):
+        if self.current_month == 1:
+            self.current_month = 12
+            self.current_year -= 1
+        else:
+            self.current_month -= 1
+        self.update_calendar()
+
+    def next_month(self):
+        if self.current_month == 12:
+            self.current_month = 1
+            self.current_year += 1
+        else:
+            self.current_month += 1
+        self.update_calendar()
+
+    def update_calendar(self):
+        self.grid.clear_widgets()
+        month_name = calendar.month_name[self.current_month]
+        self.month_label.text = f"{month_name} {self.current_year}"
+
+        days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+        for d in days:
+            self.grid.add_widget(Label(text=d))
+
+        cal = calendar.monthcalendar(self.current_year, self.current_month)
+        cal_data = self.app.calculator.get_calendar_data(self.current_year, self.current_month)
+
+        for week in cal:
+            for day in week:
+                if day == 0:
+                    self.grid.add_widget(Label(text=''))
+                else:
+                    total = cal_data.get(day, {}).get('total', 0)
+                    txt = str(day)
+                    if total != 0:
+                        txt += f"\n${total:.0f}"
+                    btn = Button(text=txt, on_release=lambda x, d=day: self.show_day(d))
+                    self.grid.add_widget(btn)
+
+    def show_day(self, day):
+        selected = date(self.current_year, self.current_month, day)
+        items = self.app.calculator.get_transactions_for_date(selected)
+        content = BoxLayout(orientation='vertical')
+        content.add_widget(Label(text=selected.strftime('%Y-%m-%d')))
+        for t in items:
+            content.add_widget(Label(text=f"{t.name}: {t.amount}"))
+        add_btn = Button(text='Add Transaction')
+        content.add_widget(add_btn)
+
+        popup = Popup(title='Day Detail', content=content, size_hint=(0.8,0.8))
+
+        def add_trans(instance):
+            popup.dismiss()
+            self.add_transaction(selected)
+
+        add_btn.bind(on_release=add_trans)
+        content.add_widget(Button(text='Close', on_release=lambda x: popup.dismiss()))
+        popup.open()
+
+    def add_transaction(self, selected_date):
+        content = BoxLayout(orientation='vertical')
+        name = TextInput(hint_text='Name')
+        amount = TextInput(hint_text='Amount', input_filter='float')
+        content.add_widget(name)
+        content.add_widget(amount)
+
+        def done(instance):
+            try:
+                t = Transaction(name.text, float(amount.text), 'expense', start_date=selected_date)
+                self.app.calculator.add_transaction(t)
+                self.app.maybe_auto_save()
+                self.update_calendar()
+                popup.dismiss()
+            except ValueError:
+                popup.dismiss()
+
+        content.add_widget(Button(text='Add', on_release=done))
+        popup = Popup(title='Add Transaction', content=content, size_hint=(0.8,0.6))
+        popup.open()
+
+class TransactionsScreen(Screen):
     def __init__(self, app, **kwargs):
         super().__init__(**kwargs)
         self.app = app
@@ -230,6 +418,7 @@ class HomeScreen(Screen):
         btn_box = BoxLayout(size_hint_y=0.1)
         btn_box.add_widget(Button(text='Add', on_release=lambda x: self.add()))
         btn_box.add_widget(Button(text='Save', on_release=lambda x: app.save_data()))
+        btn_box.add_widget(Button(text='Back', on_release=lambda x: setattr(app.sm, 'current', 'calendar')))
         layout.add_widget(btn_box)
         self.add_widget(layout)
         self.refresh()
@@ -266,7 +455,7 @@ class PaycheckScreen(Screen):
         layout.add_widget(self.view)
         btn_box = BoxLayout(size_hint_y=0.1)
         btn_box.add_widget(Button(text='Add', on_release=lambda x: self.add()))
-        btn_box.add_widget(Button(text='Back', on_release=lambda x: setattr(app.sm, 'current', 'home')))
+        btn_box.add_widget(Button(text='Back', on_release=lambda x: setattr(app.sm, 'current', 'calendar')))
         layout.add_widget(btn_box)
         self.add_widget(layout)
         self.refresh()
@@ -310,7 +499,8 @@ class BudgieAndroid(App):
         else:
             self.calculator = BudgetCalculator()
         self.sm = ScreenManager()
-        self.sm.add_widget(HomeScreen(self, name='home'))
+        self.sm.add_widget(CalendarScreen(self, name='calendar'))
+        self.sm.add_widget(TransactionsScreen(self, name='transactions'))
         self.sm.add_widget(PaycheckScreen(self, name='paychecks'))
         return self.sm
 


### PR DESCRIPTION
## Summary
- add `calendar` and `timedelta` imports in android app
- extend `BudgetCalculator` with date-based helpers used by desktop version
- add new `CalendarScreen` showing monthly calendar and day popups
- rename `HomeScreen` to `TransactionsScreen`
- add navigation between calendar, transactions, and paychecks

## Testing
- `python -m py_compile android.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6860c88337588330acd6c548b9b7dacc