### PR TITLE
Adjust left panel width for better calendar layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -1312,8 +1312,8 @@ class BudgieApp:
         main_container.grid_rowconfigure(0, weight=1)     # Full height
         
         # Left panel with fixed width (no resizing)
-        # Slightly narrower left panel so divider appears more to the left
-        left_frame = ttk.Frame(main_container, width=280)
+        # Reduced width so the calendar area has more room
+        left_frame = ttk.Frame(main_container, width=220)
         left_frame.grid(row=0, column=0, sticky="nsew", padx=(0, 5))
         left_frame.grid_propagate(False)  # Maintain fixed width
         


### PR DESCRIPTION
## Summary
- shrink the stats/action panel so the calendar grid has more room

## Testing
- `python -m py_compile app.py android.py`


------
https://chatgpt.com/codex/tasks/task_e_68678c6a062c83308b83fc920ad3f2c4