### PR TITLE
Fix analyzer graphs constant refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -3749,9 +3749,19 @@ class MonthlyAnalyzerWindow:
         # Draw charts after the window is displayed and keep them centered on resize
         self.dialog.after(100, self.update_analysis)
         self.resize_job = None
+        self.last_size = (self.dialog.winfo_width(), self.dialog.winfo_height())
         self.dialog.bind("<Configure>", self.on_resize)
 
     def on_resize(self, event):
+        # Only handle resize events from the toplevel window itself
+        if event.widget is not self.dialog:
+            return
+
+        new_size = (event.width, event.height)
+        if new_size == self.last_size:
+            return
+        self.last_size = new_size
+
         if self.resize_job:
             self.dialog.after_cancel(self.resize_job)
         # Debounce resize events to avoid excessive redraws


### PR DESCRIPTION
## Summary
- keep track of previous dialog size
- ignore `<Configure>` events from child widgets and unchanged sizes

## Testing
- `python -m py_compile app.py android.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a299dc3c83309047a91fb7bc280b