### PR TITLE
Fix calendar screen init on Android

### DIFF
--- a/android.py
+++ b/android.py
@@ -648,7 +648,7 @@ class CalendarScreen(Screen):
             row_default_height=self.cell_size,
             col_default_width=self.cell_size,
         )
-        self._update_grid_size()
+        # Grid size will be configured after the first calendar update
         layout.add_widget(self.grid)
 
         self.add_widget(layout)


### PR DESCRIPTION
## Summary
- fix grid size initialization in `android.py`

## Testing
- `python -m py_compile android.py app.py`
- `python android.py` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_686897ce58808330a04875ac34a06f39