### PR TITLE
Add placeholder text for empty lists

### DIFF
--- a/android.py
+++ b/android.py
@@ -930,6 +930,9 @@ class TransactionsScreen(Screen):
             ])
             self.summary.text += f"\nPaychecks: {p_info}"
 
+        if not items:
+            items.append('No transactions found')
+
         self.view.refresh(items)
 
     def add(self):
@@ -1026,6 +1029,11 @@ class PaycheckScreen(Screen):
 
         month_name = calendar.month_name[month]
         self.summary.text = f"{month_name} {year} - Total Net Pay: ${total:.2f}"
+
+        if not items:
+            items = ['No paychecks scheduled']
+            callbacks = [None]
+
         self.view.refresh(items, callbacks)
 
     def add(self):
@@ -1154,6 +1162,9 @@ class PortfolioScreen(Screen):
             self.summary.text = f"Total Portfolio Value: ${total:.2f} (Updated {updated})"
         else:
             self.summary.text = f"Total Portfolio Value: ${total:.2f}"
+
+        if not items:
+            items.append('No holdings recorded')
 
         self.view.refresh(items)
 


### PR DESCRIPTION
## Summary
- show 'No transactions found' on the monthly transactions page when it is empty
- show 'No paychecks scheduled' on the paychecks page when it is empty
- show 'No holdings recorded' on the crypto portfolio page when it is empty

## Testing
- `python3 -m py_compile android.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6868a4cb0ff48330ac43386653a38b60