### PR TITLE
Fix Recharts initialization in standalone HTML

### DIFF
--- a/budgie-standalone.html
+++ b/budgie-standalone.html
@@ -27,6 +27,13 @@
 
   <script type="text/babel">
     const { useState, useMemo, useEffect } = React;
+    const RechartsGlobal = window.Recharts;
+    if (!RechartsGlobal) {
+      throw new Error(
+        'Recharts library failed to load. Please check the CDN URL or network connection.'
+      );
+    }
+
     const {
       ResponsiveContainer,
       PieChart: RechartsPieChart,
@@ -39,7 +46,7 @@
       CartesianGrid,
       XAxis,
       YAxis
-    } = Recharts;
+    } = RechartsGlobal;
 
     const IconBase = ({ children, className = "", viewBox = "0 0 24 24" }) => (
       <svg


### PR DESCRIPTION
## Summary
- ensure the Recharts global is read from the window object before use
- add a fallback error to surface a missing CDN load failure

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68df9d52f4b883308456f1fa312965af